### PR TITLE
fix: change hosted app URL

### DIFF
--- a/readme.MD
+++ b/readme.MD
@@ -6,7 +6,7 @@
 
 This app allows you to download *iCal* calendar files from Facebook URL / event number.
 
-You can use it as a service at [https://fb2ical.com](https://fb2ical.com) or use this repository to launch your own instance.
+You can use it as a service at [https://fb2ical-3051b.web.app/](https://fb2ical-3051b.web.app/) or use this repository to launch your own instance.
 
 The page that is served by the app uses a service worker and can be used offline and installed as PWA (Progressive Web App).
 


### PR DESCRIPTION
I am getting rid of the domain so default Firebase URL is now
used for project URL.